### PR TITLE
Implement example conditional tab in stock status tabPanel and remove…

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -21,11 +21,7 @@ app_server <- function(input, output, session) {
   # Reactive value to store selected ecoregion
   selected_ecoregion <- reactiveVal(NULL)
   
-  # Debugging: Observe changes to selected_ecoregion
-  observe({
-    print(paste("selected_ecoregion value:", selected_ecoregion()))
-  })
-  
+
   # Initialize Modules
   mod_navigation_page_server("navigation_page_1", parent_session = session, selected_ecoregion = selected_ecoregion)
   mod_overview_server("overview_1", selected_ecoregion)

--- a/R/mod_navigation_page.R
+++ b/R/mod_navigation_page.R
@@ -149,13 +149,11 @@ mod_navigation_page_server <- function(id, parent_session, selected_ecoregion) {
     
     observeEvent(input$selected_locations, {
       req(input$selected_locations)
-      print(paste("Selected location:", input$selected_locations))
       
       temp_location <- input$selected_locations
       temp_location <- str_replace_all(temp_location, " ", "_")
       temp_location <- tolower(temp_location)
       
-      print(paste("Updating selected_ecoregion to:", temp_location))
       selected_ecoregion(temp_location)
       
       # Optional: Remove if not needed anymore

--- a/R/mod_stock_status.R
+++ b/R/mod_stock_status.R
@@ -16,6 +16,7 @@ mod_stock_status_ui <- function(id, sub_tabs) {
   ns <- NS(id)
   tagList(
     navset_tab(
+      if ("status_summary" %in% names(sub_tabs)) {
        nav_panel("Status Summary",
           layout_sidebar(
             sidebar = sidebar(width = "33vw", bg = "white", fg = "black", 
@@ -37,7 +38,7 @@ mod_stock_status_ui <- function(id, sub_tabs) {
                 
             )
           ))
-      )),
+      ))},
       
       nav_panel("Trends by group",
           layout_sidebar(


### PR DESCRIPTION
… debugging text

## Summary by Sourcery

Implement a conditional display for the 'Status Summary' tab in the stock status tabPanel and remove debugging text from the server functions.

Enhancements:
- Implement a conditional tab in the stock status tabPanel that displays the 'Status Summary' only if 'status_summary' is present in the sub_tabs.

Chores:
- Remove debugging print statements from the app_server and mod_navigation_page_server functions.