### PR TITLE
refactored discards plot to have them all in the same panel

### DIFF
--- a/R/fct_landings.R
+++ b/R/fct_landings.R
@@ -364,6 +364,7 @@ plot_discard_trends_app_plotly <- function(x, year, caption = FALSE, cap_year, c
     colors = "Set2",
     type = 'scatter',
     mode = 'lines',
+    line = list(width = 3),
     hoverinfo = 'text',
     text = ~paste(
       "Guild:", FisheriesGuild,
@@ -670,8 +671,10 @@ plot_discard_current_plotly <- function(x, year, position_letter = NULL,
     return(df5)
   }
   
+  ## rename the rows of variable guildLandings and guildDiscards to Landings and Discards
+  df5 <- dplyr::mutate(df5, variable = dplyr::recode(variable, guildLandings = "Landings", guildDiscards = "Discards"))
     # Create color scale
-  color_scale <- c("guildLandings" = "#1d9e76", "guildDiscards" = "#d86003")
+  color_scale <- c("Landings" = "#1d9e76", "Discards" = "#d86003")
   
   plot <- plotly::plot_ly(
     data = df5,
@@ -687,7 +690,7 @@ plot_discard_current_plotly <- function(x, year, position_letter = NULL,
       title = list(text = position_letter, font = list(size = 14)),
       xaxis = list(title = "Landings and Discards (thousand tonnes)"),
       yaxis = list(title = ""),
-      showlegend = FALSE,
+      showlegend = TRUE,
       margin = list(l = 100),
       annotations = if (caption) list(
         list(

--- a/R/fct_landings.R
+++ b/R/fct_landings.R
@@ -94,227 +94,9 @@ CLD_trends <- function(x){
         return(df)
 }
 
-plot_discard_trends <- function(x, year, caption = FALSE, cap_year, cap_month, return_data = FALSE){
-        df <- dplyr::filter(x,Year %in% seq(2011, year -1))
-        df2 <- tidyr::expand(df,Year, tidyr::nesting(StockKeyLabel,FisheriesGuild))
-        df <- dplyr::left_join(df,df2,
-                          by = c("Year", "StockKeyLabel", "FisheriesGuild"))
-        df3 <- dplyr::select(df, StockKeyLabel, Year, Discards)
-        df3 <- unique(df3)
-        df3 <- tibble::rowid_to_column(df3)
-        df3 <- tidyr::spread(df3,Year, Discards)
-        # df3<- dplyr::mutate(df3,`2017` = ifelse(AssessmentYear == 2017 &
-        #                                        is.na(`2017`) &
-        #                                        !is.na(`2016`),
-        #                                `2016`,
-        #                                `2017`))
-        df3 <- tidyr::gather(df3,Year, Discards, 4:ncol(df3))
-        df3 <- dplyr::mutate(df3,Year = as.numeric(Year),
-                       Discards = as.numeric(Discards))
 
-        df4<- dplyr::select(df,StockKeyLabel, Year, Landings)
-        df4 <- unique(df4)
-        df4 <- tibble::rowid_to_column(df4)
-        df4 <- dplyr::group_by(df4,StockKeyLabel)
-        df4 <- tidyr::spread(df4,Year, Landings)
-        # df4 <- dplyr::mutate(df4,`2017` = ifelse(AssessmentYear == 2017 &
-        #                                        is.na(`2017`) &
-        #                                        !is.na(`2016`),
-        #                                `2016`,
-        #                                `2017`))
-        df4 <- tidyr::gather(df4,Year, Landings, 4:ncol(df4))
-        df4 <- dplyr::mutate(df4,Year = as.numeric(Year),
-                       Landings = as.numeric(Landings))
-        df5 <- dplyr::select(df,-Discards,
-                       -Landings)
-        df5 <- dplyr::left_join(df5,df3, by = c("Year", "StockKeyLabel"))
-        df5 <- dplyr::left_join(df5,df4, by = c("Year", "StockKeyLabel"))
-        df5 <- dplyr::group_by(df5,Year, FisheriesGuild)
-        df5 <- dplyr::summarize(df5, guildLandings = sum(Landings, na.rm = TRUE)/ 1000,
-                          guildDiscards = sum(Discards, na.rm = TRUE)/ 1000)
-
-        df5 <- dplyr::mutate(df5,guildRate = guildDiscards/ (guildLandings + guildDiscards))
-        df5 <- tidyr::gather(df5,variable, value, -Year, -FisheriesGuild)
-        df5 <- dplyr::filter(df5,!variable %in% c("guildDiscards", "guildLandings"))
-        df5 <- dplyr::filter(df5,!is.na(value))
-        df5 <- dplyr::filter(df5, value > 0)
-        df6 <- df5 %>% dplyr::group_by(FisheriesGuild) %>% dplyr::slice(which.max(Year))
-        plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                               ggplot2::aes(x = Year,
-                                   y = value,
-                                   color = FisheriesGuild)) +
-                ggplot2::geom_line() +
-                ggrepel::geom_label_repel(data = df6,
-                                          ggplot2::aes(label = FisheriesGuild,
-                                              color = FisheriesGuild,
-                                              fill = FisheriesGuild),
-                                          nudge_x = 1,
-                                          label.size = 0.2,
-                                          segment.size = 0.25,
-                                          size = 2,
-                                          color = 'white',
-                                          force = 2,
-                                          segment.color = 'grey60') +
-                ggplot2::scale_y_continuous(labels = scales::percent) +
-                ggplot2::scale_x_continuous(breaks = seq(min(df5$Year, na.rm = TRUE),
-                                                max(df5$Year, na.rm = TRUE), by = 2)) +
-                ggplot2::geom_segment(ggplot2::aes(x = -Inf, xend = max(df5$Year, na.rm = TRUE),
-                                 y = -Inf, yend = -Inf), color = "grey50") +
-                ggplot2::geom_segment(ggplot2::aes(y = -Inf, yend = Inf,
-                                 x = -Inf, xend = -Inf), color = "grey50")+
-                ggplot2::expand_limits(x = c(min(df5$Year, na.rm = TRUE), year + 1)) +
-                ggplot2::scale_color_brewer(type = "qual", palette = "Set2") +
-                ggplot2::scale_fill_brewer(type = "qual", palette = "Set2") +
-                ggplot2::theme_bw(base_size = 9) +
-                ggplot2::theme(legend.position = "none",
-                      plot.caption = ggplot2::element_text(size = 6),
-                      panel.grid = ggplot2::element_blank(),
-                      legend.key = ggplot2::element_rect(colour = NA)) +
-                ggplot2::labs(x = "Year", y = "Discard rate", caption = "", title = "a)")
-
-        if(caption == TRUE){
-                cap_lab <- ggplot2::labs(caption = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen",
-                                                           cap_month,
-                                                           cap_year))
-                plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                                        ggplot2::aes(x = Year,
-                                                     y = value,
-                                                     color = FisheriesGuild)) +
-                        ggplot2::geom_line() +
-                        ggrepel::geom_label_repel(data = df6,
-                                                  ggplot2::aes(label = FisheriesGuild,
-                                                               color = FisheriesGuild,
-                                                               fill = FisheriesGuild),
-                                                  nudge_x = 1,
-                                                  label.size = 0.2,
-                                                  segment.size = 0.25,
-                                                  size = 2,
-                                                  color = 'white',
-                                                  force = 2,
-                                                  segment.color = 'grey60') +
-                        ggplot2::scale_y_continuous(labels = scales::percent) +
-                        ggplot2::scale_x_continuous(breaks = seq(min(df5$Year, na.rm = TRUE),
-                                                                 max(df5$Year, na.rm = TRUE), by = 2)) +
-                        ggplot2::geom_segment(ggplot2::aes(x = min(df5$Year), xend = max(df5$Year, na.rm = TRUE),
-                                                           y = -Inf, yend = -Inf), color = "grey50") +
-                        ggplot2::geom_segment(ggplot2::aes(y = -Inf, yend = Inf,
-                                                           x = min(df5$Year), xend = -Inf), color = "grey50")+
-                        ggplot2::expand_limits(x = c(min(df5$Year, na.rm = TRUE), year + 1)) +
-                        ggplot2::scale_color_brewer(type = "qual", palette = "Set2") +
-                        ggplot2::scale_fill_brewer(type = "qual", palette = "Set2") +
-                        ggplot2::theme_bw(base_size = 9) +
-                        ggplot2::theme(legend.position = "none",
-                                       plot.caption = ggplot2::element_text(size = 6),
-                                       panel.grid = ggplot2::element_blank(),
-                                       legend.key = ggplot2::element_rect(colour = NA)) +
-                        ggplot2::labs(x = "Year", y = "Discard rate", caption = "", title = "a)")+
-                        cap_lab
-
-        }
-
-        if(return_data == TRUE){
-                df5
-        }else{
-                plot
-        }
-}
-
-
-plot_discard_trends_app <- function(x, year, caption = FALSE, cap_year, cap_month, return_data = FALSE){
-        df <- dplyr::filter(x,Year %in% seq(2011, year -1))
-        df2 <- tidyr::expand(df,Year, tidyr::nesting(StockKeyLabel,FisheriesGuild))
-        df <- dplyr::left_join(df,df2,
-                          by = c("Year", "StockKeyLabel", "FisheriesGuild"))
-        df3 <- dplyr::select(df, StockKeyLabel, Year, Discards)
-        df3 <- unique(df3)
-        df3 <- tibble::rowid_to_column(df3)
-        df3 <- tidyr::spread(df3,Year, Discards)
-        df3 <- tidyr::gather(df3,Year, Discards, 4:ncol(df3))
-        df3 <- dplyr::mutate(df3,Year = as.numeric(Year),
-                       Discards = as.numeric(Discards))
-
-        df4<- dplyr::select(df,StockKeyLabel, Year, Landings)
-        df4 <- unique(df4)
-        df4 <- tibble::rowid_to_column(df4)
-        df4 <- dplyr::group_by(df4,StockKeyLabel)
-        df4 <- tidyr::spread(df4,Year, Landings)
-        df4 <- tidyr::gather(df4,Year, Landings, 4:ncol(df4))
-        df4 <- dplyr::mutate(df4,Year = as.numeric(Year),
-                       Landings = as.numeric(Landings))
-        df5 <- dplyr::select(df,-Discards,
-                       -Landings)
-        df5 <- dplyr::left_join(df5,df3, by = c("Year", "StockKeyLabel"))
-        df5 <- dplyr::left_join(df5,df4, by = c("Year", "StockKeyLabel"))
-        df5 <- dplyr::group_by(df5,Year, FisheriesGuild)
-        df5 <- dplyr::summarize(df5, guildLandings = sum(Landings, na.rm = TRUE)/ 1000,
-                          guildDiscards = sum(Discards, na.rm = TRUE)/ 1000)
-
-        df5 <- dplyr::mutate(df5,guildRate = guildDiscards/ (guildLandings + guildDiscards))
-        df5 <- tidyr::gather(df5,variable, value, -Year, -FisheriesGuild)
-        df5 <- dplyr::filter(df5,!variable %in% c("guildDiscards", "guildLandings"))
-        df5 <- dplyr::filter(df5,!is.na(value))
-        df6 <- dplyr::filter(df5, Year == year - 1)
-        plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                               ggplot2::aes(x = Year,
-                                   y = value,
-                                   color = FisheriesGuild)) +
-                ggplot2::geom_line() +
-                ggplot2::scale_y_continuous(labels = scales::percent) +
-                ggplot2::scale_x_continuous(breaks = seq(min(df5$Year, na.rm = TRUE),
-                                                max(df5$Year, na.rm = TRUE), by = 1)) +
-                ggplot2::geom_segment(ggplot2::aes(x = -Inf, xend = max(df5$Year, na.rm = TRUE),
-                                 y = -Inf, yend = -Inf), color = "grey50") +
-                ggplot2::geom_segment(ggplot2::aes(y = -Inf, yend = Inf,
-                                 x = -Inf, xend = -Inf), color = "grey50")+
-                ggplot2::expand_limits(x = c(min(df5$Year, na.rm = TRUE), year + 1)) +
-                ggplot2::scale_color_brewer(type = "qual", palette = "Set2") +
-                ggplot2::scale_fill_brewer(type = "qual", palette = "Set2") +
-                ggplot2::theme_bw(base_size = 15) +
-                ggplot2::theme(legend.position = "right",
-                      plot.caption = ggplot2::element_text(size = 10),
-                      panel.grid = ggplot2::element_blank(),
-                      legend.key = ggplot2::element_rect(colour = NA)) +
-                ggplot2::labs(x = "Year", y = "Discard rate", caption = "")
-
-
-        if(caption == TRUE){
-                cap_lab <- ggplot2::labs(caption = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen",
-                                                           cap_month,
-                                                           cap_year))
-                plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                                        ggplot2::aes(x = Year,
-                                                     y = value,
-                                                     color = FisheriesGuild)) +
-                        ggplot2::geom_line() +
-                        ggplot2::scale_y_continuous(labels = scales::percent) +
-                        ggplot2::scale_x_continuous(breaks = seq(min(df5$Year, na.rm = TRUE),
-                                                                 max(df5$Year, na.rm = TRUE), by = 1)) +
-                        ggplot2::geom_segment(ggplot2::aes(x = min(df5$Year), xend = max(df5$Year, na.rm = TRUE),
-                                                           y = -Inf, yend = -Inf), color = "grey50") +
-                        ggplot2::geom_segment(ggplot2::aes(y = -Inf, yend = Inf,
-                                                           x = min(df5$Year), xend = -Inf), color = "grey50")+
-                        ggplot2::expand_limits(x = c(min(df5$Year, na.rm = TRUE), year + 1)) +
-                        ggplot2::scale_color_brewer(type = "qual", palette = "Set2") +
-                        ggplot2::scale_fill_brewer(type = "qual", palette = "Set2") +
-                        ggplot2::theme_bw(base_size = 15) +
-                        ggplot2::theme(legend.position = "right",
-                                       plot.caption = ggplot2::element_text(size = 10),
-                                       panel.grid = ggplot2::element_blank(),
-                                       legend.key = ggplot2::element_rect(colour = NA)) +
-                        ggplot2::labs(x = "Year", y = "Discard rate", caption = "")+
-                        cap_lab
-
-        }
-
-        if(return_data == TRUE){
-                df5
-        }else{
-                plot
-        }
-}
 
 plot_discard_trends_app_plotly <- function(x, year, caption = FALSE, cap_year, cap_month, return_data = FALSE) {
-
   df <- dplyr::filter(x, Year %in% seq(2011, year - 1))
   df2 <- tidyr::expand(df, Year, tidyr::nesting(StockKeyLabel, FisheriesGuild))
   df <- dplyr::left_join(df, df2, by = c("Year", "StockKeyLabel", "FisheriesGuild"))
@@ -325,8 +107,10 @@ plot_discard_trends_app_plotly <- function(x, year, caption = FALSE, cap_year, c
     tibble::rowid_to_column() %>%
     tidyr::spread(Year, Discards) %>%
     tidyr::gather(Year, Discards, 4:ncol(.)) %>%
-    dplyr::mutate(Year = as.numeric(Year),
-                  Discards = as.numeric(Discards))
+    dplyr::mutate(
+      Year = as.numeric(Year),
+      Discards = as.numeric(Discards)
+    )
 
   df4 <- df %>%
     dplyr::select(StockKeyLabel, Year, Landings) %>%
@@ -335,8 +119,10 @@ plot_discard_trends_app_plotly <- function(x, year, caption = FALSE, cap_year, c
     dplyr::group_by(StockKeyLabel) %>%
     tidyr::spread(Year, Landings) %>%
     tidyr::gather(Year, Landings, 4:ncol(.)) %>%
-    dplyr::mutate(Year = as.numeric(Year),
-                  Landings = as.numeric(Landings))
+    dplyr::mutate(
+      Year = as.numeric(Year),
+      Landings = as.numeric(Landings)
+    )
 
   df5 <- df %>%
     dplyr::select(-Discards, -Landings) %>%
@@ -362,11 +148,11 @@ plot_discard_trends_app_plotly <- function(x, year, caption = FALSE, cap_year, c
     y = ~value,
     color = ~FisheriesGuild,
     colors = "Set2",
-    type = 'scatter',
-    mode = 'lines',
+    type = "scatter",
+    mode = "lines",
     line = list(width = 3),
-    hoverinfo = 'text',
-    text = ~paste(
+    hoverinfo = "text",
+    text = ~ paste(
       "Guild:", FisheriesGuild,
       "<br>Year:", Year,
       "<br>Discard rate:", scales::percent(value, accuracy = 0.1)
@@ -375,246 +161,260 @@ plot_discard_trends_app_plotly <- function(x, year, caption = FALSE, cap_year, c
 
   p <- plotly::layout(
     p,
-    yaxis = list(title = "Discard rate", tickformat = ".0%"),
-    xaxis = list(title = "Year", dtick = 1),
+    yaxis = list(
+      title = "Discard rate",
+      tickformat = ".0%",
+      font = list(size = 14),
+      tickfont = list(size = 13)
+    ),
+    xaxis = list(
+      title = "Year",
+      dtick = 1,
+      font = list(size = 14),
+      tickfont = list(size = 13)
+    ),
     legend = list(title = list(text = "<b>Fisheries Guild</b>")),
     margin = list(t = ifelse(caption, 80, 50)),
-    annotations = if (caption) list(
+    annotations = if (caption) {
       list(
-        xref = "paper", yref = "paper",
-        x = 0, y = 1.1, showarrow = FALSE,
-        text = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen", cap_month, cap_year),
-        font = list(size = 12)
+        list(
+          xref = "paper", yref = "paper",
+          x = 0, y = 1.1, showarrow = FALSE,
+          text = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen", cap_month, cap_year),
+          font = list(size = 12)
+        )
       )
-    ) else NULL
+    } else {
+      NULL
+    }
   )
 
   return(p)
 }
 
 
-plot_discard_current <- function(x, year, position_letter = "c)",
-                                 caption = TRUE, cap_year, cap_month,
-                                 return_data = FALSE){
-  df <- dplyr::filter(x,Year %in% seq(year-5, year -1))
-  df2 <- tidyr::expand(df,Year, tidyr::nesting(StockKeyLabel,FisheriesGuild))
-  df <- dplyr::left_join(df,df2,
-                         by = c("Year", "StockKeyLabel", "FisheriesGuild"))
-  # df <- df[, -11]
-  df3 <- dplyr::select(df, StockKeyLabel, Year, Discards)
-  df3 <- unique(df3)
-  df3 <- tibble::rowid_to_column(df3)
-  df3 <- dplyr::group_by(df3,StockKeyLabel)
-  df3 <- tidyr::spread(df3,Year, Discards)
-  # df3<- dplyr::mutate(df3,`2017` = ifelse(AssessmentYear == 2017 &
-  #                                                 is.na(`2017`) &
-  #                                                 !is.na(`2016`),
-  #                                         `2016`,
-  #                                         `2017`))
-  df3 <- tidyr::gather(df3,Year, Discards, 3:ncol(df3))
-  df3 <- dplyr::mutate(df3,Year = as.numeric(Year),
-                       Discards = as.numeric(Discards))
-  df5 <- dplyr::select(df,-Discards)
-  df5 <- dplyr::left_join(df5,df3, by = c("Year", "StockKeyLabel"))
+# plot_discard_current <- function(x, year, position_letter = "c)",
+#                                  caption = TRUE, cap_year, cap_month,
+#                                  return_data = FALSE){
+#   df <- dplyr::filter(x,Year %in% seq(year-5, year -1))
+#   df2 <- tidyr::expand(df,Year, tidyr::nesting(StockKeyLabel,FisheriesGuild))
+#   df <- dplyr::left_join(df,df2,
+#                          by = c("Year", "StockKeyLabel", "FisheriesGuild"))
+#   # df <- df[, -11]
+#   df3 <- dplyr::select(df, StockKeyLabel, Year, Discards)
+#   df3 <- unique(df3)
+#   df3 <- tibble::rowid_to_column(df3)
+#   df3 <- dplyr::group_by(df3,StockKeyLabel)
+#   df3 <- tidyr::spread(df3,Year, Discards)
+#   # df3<- dplyr::mutate(df3,`2017` = ifelse(AssessmentYear == 2017 &
+#   #                                                 is.na(`2017`) &
+#   #                                                 !is.na(`2016`),
+#   #                                         `2016`,
+#   #                                         `2017`))
+#   df3 <- tidyr::gather(df3,Year, Discards, 3:ncol(df3))
+#   df3 <- dplyr::mutate(df3,Year = as.numeric(Year),
+#                        Discards = as.numeric(Discards))
+#   df5 <- dplyr::select(df,-Discards)
+#   df5 <- dplyr::left_join(df5,df3, by = c("Year", "StockKeyLabel"))
   
-  df5$sum <- rowSums(df5[ , c(8:9,11)], na.rm = T)
-  df5 <- dplyr::group_by(df5,Year, StockKeyLabel) %>% dplyr::slice_max(order_by = sum, n = 1, with_ties = FALSE)
+#   df5$sum <- rowSums(df5[ , c(8:9,11)], na.rm = T)
+#   df5 <- dplyr::group_by(df5,Year, StockKeyLabel) %>% dplyr::slice_max(order_by = sum, n = 1, with_ties = FALSE)
   
-  # df5 <- dplyr::left_join(df5,df4, by = c("Year", "StockKeyLabel", "AssessmentYear"))
+#   # df5 <- dplyr::left_join(df5,df4, by = c("Year", "StockKeyLabel", "AssessmentYear"))
   
          
-  df5$Landings <- as.numeric(df5$Landings)
-  df5$Catches <- as.numeric(df5$Catches)
-  df5$Discards <- as.numeric(df5$Discards)
+#   df5$Landings <- as.numeric(df5$Landings)
+#   df5$Catches <- as.numeric(df5$Catches)
+#   df5$Discards <- as.numeric(df5$Discards)
   
-  df5[is.na(df5)] <- 0
-  df5 <- unique(df5)
+#   df5[is.na(df5)] <- 0
+#   df5 <- unique(df5)
   
-  df5 <- df5 %>% group_by(Year, FisheriesGuild) %>% summarise(across(where(is.numeric),sum))
-  df5$Landings <- ifelse(!is.na(df5$Landings), df5$Landings, df5$Catches)
+#   df5 <- df5 %>% group_by(Year, FisheriesGuild) %>% summarise(across(where(is.numeric),sum))
+#   df5$Landings <- ifelse(!is.na(df5$Landings), df5$Landings, df5$Catches)
   
 
-  # df7 <- dplyr::summarize(df5,guildLandings = sum(Landings, na.rm = TRUE),
-  #                        guildDiscards = sum(Discards, na.rm = TRUE))
-  # 
-  # df5 <- dplyr::mutate(df5,guildRate = guildDiscards/ (guildLandings + guildDiscards))
-  names(df5)[names(df5) == "Landings"] <- "guildLandings"
-  names(df5)[names(df5) == "Discards"] <- "guildDiscards"
+#   # df7 <- dplyr::summarize(df5,guildLandings = sum(Landings, na.rm = TRUE),
+#   #                        guildDiscards = sum(Discards, na.rm = TRUE))
+#   # 
+#   # df5 <- dplyr::mutate(df5,guildRate = guildDiscards/ (guildLandings + guildDiscards))
+#   names(df5)[names(df5) == "Landings"] <- "guildLandings"
+#   names(df5)[names(df5) == "Discards"] <- "guildDiscards"
   
   
-  df5 <- tidyr::gather(df5,variable, value, -Year, -FisheriesGuild)
-  df5 <- dplyr::filter(df5, variable %in% c("guildLandings", "guildDiscards"))
-  df5 <- dplyr::filter(df5,Year == year-1)
-  df5$value <- df5$value/1000
+#   df5 <- tidyr::gather(df5,variable, value, -Year, -FisheriesGuild)
+#   df5 <- dplyr::filter(df5, variable %in% c("guildLandings", "guildDiscards"))
+#   df5 <- dplyr::filter(df5,Year == year-1)
+#   df5$value <- df5$value/1000
 
-  # df5 <- dplyr::filter(df5,!variable %in% c("guildDiscards", "guildLandings"))
-  #out?
-  # df5 <- dplyr::filter(df5,Year == year - 1)
+#   # df5 <- dplyr::filter(df5,!variable %in% c("guildDiscards", "guildLandings"))
+#   #out?
+#   # df5 <- dplyr::filter(df5,Year == year - 1)
 
-  # df5_order <- dplyr::group_by(df5,FisheriesGuild) %>%
-  #         summarize(total = sum(value, na.rm = TRUE)) %>%
-  #         arrange(-total) %>%
-  #         ungroup()
-  # df5_order <- dplyr::mutate(df5_order,FisheriesGuild = factor(FisheriesGuild, FisheriesGuild))
+#   # df5_order <- dplyr::group_by(df5,FisheriesGuild) %>%
+#   #         summarize(total = sum(value, na.rm = TRUE)) %>%
+#   #         arrange(-total) %>%
+#   #         ungroup()
+#   # df5_order <- dplyr::mutate(df5_order,FisheriesGuild = factor(FisheriesGuild, FisheriesGuild))
 
-  # df5$FisheriesGuild <- factor(df5$FisheriesGuild,
-  #                                 levels = df5_order$FisheriesGuild[order(df5_order$total)])
-  plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                          ggplot2::aes(x = reorder(FisheriesGuild, value, sum), y = value, fill = variable)) +
-          ggplot2::geom_bar(stat = "identity") +
-          ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
-          ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
-          ggplot2::coord_flip() +
-          ggplot2::theme_bw(base_size = 8) +
-          ggplot2::theme(legend.position = "none",
-                plot.caption = ggplot2::element_text(size = 6),
-                panel.grid = ggplot2::element_blank(),
-                legend.key = ggplot2::element_rect(colour = NA)) +
-          ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)
+#   # df5$FisheriesGuild <- factor(df5$FisheriesGuild,
+#   #                                 levels = df5_order$FisheriesGuild[order(df5_order$total)])
+#   plot <- ggplot2::ggplot(dplyr::ungroup(df5),
+#                           ggplot2::aes(x = reorder(FisheriesGuild, value, sum), y = value, fill = variable)) +
+#           ggplot2::geom_bar(stat = "identity") +
+#           ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#           ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#           ggplot2::coord_flip() +
+#           ggplot2::theme_bw(base_size = 8) +
+#           ggplot2::theme(legend.position = "none",
+#                 plot.caption = ggplot2::element_text(size = 6),
+#                 panel.grid = ggplot2::element_blank(),
+#                 legend.key = ggplot2::element_rect(colour = NA)) +
+#           ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)
 
-  if(caption == TRUE) {
-    cap_lab <- ggplot2::labs(caption = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen",
-                                               cap_month,
-                                               cap_year))
-    # df5$value <- df5$value/100
+#   if(caption == TRUE) {
+#     cap_lab <- ggplot2::labs(caption = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen",
+#                                                cap_month,
+#                                                cap_year))
+#     # df5$value <- df5$value/100
     
-    plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                            ggplot2::aes(x = reorder(FisheriesGuild, value, sum), y = value, fill = variable)) +
-            ggplot2::geom_bar(stat = "identity") +
-            ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
-            ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
-            ggplot2::coord_flip() +
-            ggplot2::theme_bw(base_size = 8) +
-            ggplot2::theme(legend.position = "none",
-                           plot.caption = ggplot2::element_text(size = 6),
-                           panel.grid = ggplot2::element_blank(),
-                           legend.key = ggplot2::element_rect(colour = NA)) +
-            ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)+
-            cap_lab
-  }
+#     plot <- ggplot2::ggplot(dplyr::ungroup(df5),
+#                             ggplot2::aes(x = reorder(FisheriesGuild, value, sum), y = value, fill = variable)) +
+#             ggplot2::geom_bar(stat = "identity") +
+#             ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#             ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#             ggplot2::coord_flip() +
+#             ggplot2::theme_bw(base_size = 8) +
+#             ggplot2::theme(legend.position = "none",
+#                            plot.caption = ggplot2::element_text(size = 6),
+#                            panel.grid = ggplot2::element_blank(),
+#                            legend.key = ggplot2::element_rect(colour = NA)) +
+#             ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)+
+#             cap_lab
+#   }
 
-  if(return_data == T){
-          df5$value <- df5$value*1000
-          df5
-  }else{
-          plot
-  }
+#   if(return_data == T){
+#           df5$value <- df5$value*1000
+#           df5
+#   }else{
+#           plot
+#   }
 
-}
+# }
 
 
-plot_discard_current_order <- function(x, year, order_df,position_letter = "c)",
-                                 caption = TRUE, cap_year, cap_month,
-                                 return_data = FALSE){
-        df <- dplyr::filter(x,Year %in% seq(year-5, year -1))
-        df2 <- tidyr::expand(df,Year, tidyr::nesting(StockKeyLabel,FisheriesGuild))
-        df <- dplyr::left_join(df,df2,
-                               by = c("Year", "StockKeyLabel", "FisheriesGuild"))
-        # df <- df[, -11]
-        df3 <- dplyr::select(df, StockKeyLabel, Year, Discards)
-        df3 <- unique(df3)
-        df3 <- tibble::rowid_to_column(df3)
-        df3 <- dplyr::group_by(df3,StockKeyLabel)
-        df3 <- tidyr::spread(df3,Year, Discards)
-        # df3<- dplyr::mutate(df3,`2017` = ifelse(AssessmentYear == 2017 &
-        #                                                 is.na(`2017`) &
-        #                                                 !is.na(`2016`),
-        #                                         `2016`,
-        #                                         `2017`))
-        df3 <- tidyr::gather(df3,Year, Discards, 3:ncol(df3))
-        df3 <- dplyr::mutate(df3,Year = as.numeric(Year),
-                             Discards = as.numeric(Discards))
-        df5 <- dplyr::select(df,-Discards)
-        df5 <- dplyr::left_join(df5,df3, by = c("Year", "StockKeyLabel"))
+# plot_discard_current_order <- function(x, year, order_df,position_letter = "c)",
+#                                  caption = TRUE, cap_year, cap_month,
+#                                  return_data = FALSE){
+#         df <- dplyr::filter(x,Year %in% seq(year-5, year -1))
+#         df2 <- tidyr::expand(df,Year, tidyr::nesting(StockKeyLabel,FisheriesGuild))
+#         df <- dplyr::left_join(df,df2,
+#                                by = c("Year", "StockKeyLabel", "FisheriesGuild"))
+#         # df <- df[, -11]
+#         df3 <- dplyr::select(df, StockKeyLabel, Year, Discards)
+#         df3 <- unique(df3)
+#         df3 <- tibble::rowid_to_column(df3)
+#         df3 <- dplyr::group_by(df3,StockKeyLabel)
+#         df3 <- tidyr::spread(df3,Year, Discards)
+#         # df3<- dplyr::mutate(df3,`2017` = ifelse(AssessmentYear == 2017 &
+#         #                                                 is.na(`2017`) &
+#         #                                                 !is.na(`2016`),
+#         #                                         `2016`,
+#         #                                         `2017`))
+#         df3 <- tidyr::gather(df3,Year, Discards, 3:ncol(df3))
+#         df3 <- dplyr::mutate(df3,Year = as.numeric(Year),
+#                              Discards = as.numeric(Discards))
+#         df5 <- dplyr::select(df,-Discards)
+#         df5 <- dplyr::left_join(df5,df3, by = c("Year", "StockKeyLabel"))
         
-        df5$sum <- rowSums(df5[ , c(8:9,11)], na.rm = T)
-        df5 <- dplyr::group_by(df5,Year, StockKeyLabel)%>% top_n(1,sum)
+#         df5$sum <- rowSums(df5[ , c(8:9,11)], na.rm = T)
+#         df5 <- dplyr::group_by(df5,Year, StockKeyLabel)%>% top_n(1,sum)
         
-        # df5 <- dplyr::left_join(df5,df4, by = c("Year", "StockKeyLabel", "AssessmentYear"))
-        
-        
-        df5$Landings <- as.numeric(df5$Landings)
-        df5$Catches <- as.numeric(df5$Catches)
-        df5$Discards <- as.numeric(df5$Discards)
-        
-        df5[is.na(df5)] <- 0
-        df5 <- unique(df5)
-        
-        df5 <- df5 %>% group_by(Year, FisheriesGuild) %>% summarise(across(where(is.numeric),sum))
-        df5$Landings <- ifelse(!is.na(df5$Landings), df5$Landings, df5$Catches)
+#         # df5 <- dplyr::left_join(df5,df4, by = c("Year", "StockKeyLabel", "AssessmentYear"))
         
         
-        # df7 <- dplyr::summarize(df5,guildLandings = sum(Landings, na.rm = TRUE),
-        #                        guildDiscards = sum(Discards, na.rm = TRUE))
-        # 
-        # df5 <- dplyr::mutate(df5,guildRate = guildDiscards/ (guildLandings + guildDiscards))
-        names(df5)[names(df5) == "Landings"] <- "guildLandings"
-        names(df5)[names(df5) == "Discards"] <- "guildDiscards"
+#         df5$Landings <- as.numeric(df5$Landings)
+#         df5$Catches <- as.numeric(df5$Catches)
+#         df5$Discards <- as.numeric(df5$Discards)
+        
+#         df5[is.na(df5)] <- 0
+#         df5 <- unique(df5)
+        
+#         df5 <- df5 %>% group_by(Year, FisheriesGuild) %>% summarise(across(where(is.numeric),sum))
+#         df5$Landings <- ifelse(!is.na(df5$Landings), df5$Landings, df5$Catches)
         
         
-        df5 <- tidyr::gather(df5,variable, value, -Year, -FisheriesGuild)
-        df5 <- dplyr::filter(df5, variable %in% c("guildLandings", "guildDiscards"))
-        df5 <- dplyr::filter(df5,Year == year-1)
-        df5$value <- df5$value/1000
+#         # df7 <- dplyr::summarize(df5,guildLandings = sum(Landings, na.rm = TRUE),
+#         #                        guildDiscards = sum(Discards, na.rm = TRUE))
+#         # 
+#         # df5 <- dplyr::mutate(df5,guildRate = guildDiscards/ (guildLandings + guildDiscards))
+#         names(df5)[names(df5) == "Landings"] <- "guildLandings"
+#         names(df5)[names(df5) == "Discards"] <- "guildDiscards"
         
-        # df5 <- dplyr::filter(df5,!variable %in% c("guildDiscards", "guildLandings"))
-        #out?
-        # df5 <- dplyr::filter(df5,Year == year - 1)
         
-        # df5_order <- dplyr::group_by(df5,FisheriesGuild) %>%
-        #         summarize(total = sum(value, na.rm = TRUE)) %>%
-        #         arrange(-total) %>%
-        #         ungroup()
-        # df5_order <- dplyr::mutate(df5_order,FisheriesGuild = factor(FisheriesGuild, FisheriesGuild))
+#         df5 <- tidyr::gather(df5,variable, value, -Year, -FisheriesGuild)
+#         df5 <- dplyr::filter(df5, variable %in% c("guildLandings", "guildDiscards"))
+#         df5 <- dplyr::filter(df5,Year == year-1)
+#         df5$value <- df5$value/1000
         
-        # df5$FisheriesGuild <- factor(df5$FisheriesGuild,
-        #                                 levels = df5_order$FisheriesGuild[order(df5_order$total)])
-        plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                                ggplot2::aes(x = reorder(order_df$FisheriesGuild, order_df$value, sum), y = value, fill = variable)) +
-                ggplot2::geom_bar(stat = "identity") +
-                ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
-                ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
-                ggplot2::coord_flip() +
-                ggplot2::theme_bw(base_size = 8) +
-                ggplot2::theme(legend.position = "none",
-                               plot.caption = ggplot2::element_text(size = 6),
-                               panel.grid = ggplot2::element_blank(),
-                               legend.key = ggplot2::element_rect(colour = NA)) +
-                ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)
+#         # df5 <- dplyr::filter(df5,!variable %in% c("guildDiscards", "guildLandings"))
+#         #out?
+#         # df5 <- dplyr::filter(df5,Year == year - 1)
         
-        if(caption == TRUE) {
-                cap_lab <- ggplot2::labs(caption = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen",
-                                                           cap_month,
-                                                           cap_year))
-                # df5$value <- df5$value/100
+#         # df5_order <- dplyr::group_by(df5,FisheriesGuild) %>%
+#         #         summarize(total = sum(value, na.rm = TRUE)) %>%
+#         #         arrange(-total) %>%
+#         #         ungroup()
+#         # df5_order <- dplyr::mutate(df5_order,FisheriesGuild = factor(FisheriesGuild, FisheriesGuild))
+        
+#         # df5$FisheriesGuild <- factor(df5$FisheriesGuild,
+#         #                                 levels = df5_order$FisheriesGuild[order(df5_order$total)])
+#         plot <- ggplot2::ggplot(dplyr::ungroup(df5),
+#                                 ggplot2::aes(x = reorder(order_df$FisheriesGuild, order_df$value, sum), y = value, fill = variable)) +
+#                 ggplot2::geom_bar(stat = "identity") +
+#                 ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#                 ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#                 ggplot2::coord_flip() +
+#                 ggplot2::theme_bw(base_size = 8) +
+#                 ggplot2::theme(legend.position = "none",
+#                                plot.caption = ggplot2::element_text(size = 6),
+#                                panel.grid = ggplot2::element_blank(),
+#                                legend.key = ggplot2::element_rect(colour = NA)) +
+#                 ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)
+        
+#         if(caption == TRUE) {
+#                 cap_lab <- ggplot2::labs(caption = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen",
+#                                                            cap_month,
+#                                                            cap_year))
+#                 # df5$value <- df5$value/100
                 
-                plot <- ggplot2::ggplot(dplyr::ungroup(df5),
-                                        ggplot2::aes(x = reorder(order_df$FisheriesGuild, order_df$value, sum), y = value, fill = variable)) +
-                        ggplot2::geom_bar(stat = "identity") +
-                        ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
-                        ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
-                        ggplot2::coord_flip() +
-                        ggplot2::theme_bw(base_size = 8) +
-                        ggplot2::theme(legend.position = "none",
-                                       plot.caption = ggplot2::element_text(size = 6),
-                                       panel.grid = ggplot2::element_blank(),
-                                       legend.key = ggplot2::element_rect(colour = NA)) +
-                        ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)+
-                        cap_lab
-        }
+#                 plot <- ggplot2::ggplot(dplyr::ungroup(df5),
+#                                         ggplot2::aes(x = reorder(order_df$FisheriesGuild, order_df$value, sum), y = value, fill = variable)) +
+#                         ggplot2::geom_bar(stat = "identity") +
+#                         ggplot2::scale_color_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#                         ggplot2::scale_fill_brewer(type = "qual", palette = "Dark2", direction = -1) +
+#                         ggplot2::coord_flip() +
+#                         ggplot2::theme_bw(base_size = 8) +
+#                         ggplot2::theme(legend.position = "none",
+#                                        plot.caption = ggplot2::element_text(size = 6),
+#                                        panel.grid = ggplot2::element_blank(),
+#                                        legend.key = ggplot2::element_rect(colour = NA)) +
+#                         ggplot2::labs(x = "", y = "Landings and Discards(thousand tonnes)",title = position_letter)+
+#                         cap_lab
+#         }
         
-        if(return_data == T){
-                df5$value <- df5$value*1000
-                df5
-        }else{
-                plot
-        }
+#         if(return_data == T){
+#                 df5$value <- df5$value*1000
+#                 df5
+#         }else{
+#                 plot
+#         }
         
-}
+# }
 
 
 plot_discard_current_plotly <- function(x, year, position_letter = NULL,
-                                        caption = TRUE, cap_year, cap_month,
+                                        caption = FALSE, cap_year, cap_month,
                                         return_data = FALSE, order_df = NULL) {
   df <- dplyr::filter(x, Year %in% seq(year - 5, year - 1))
   df2 <- tidyr::expand(df, Year, tidyr::nesting(StockKeyLabel, FisheriesGuild))
@@ -687,16 +487,21 @@ plot_discard_current_plotly <- function(x, year, position_letter = NULL,
   ) %>%
     plotly::layout(
       barmode = "stack",
-      title = list(text = position_letter, font = list(size = 14)),
-      xaxis = list(title = "Landings and Discards (thousand tonnes)"),
-      yaxis = list(title = ""),
+      title = list(text = position_letter, font = list(size = 15)),
+      xaxis = list(
+        title = "Discards and Landings (thousand tonnes)", 
+        font = list(size = 14),
+        tickfont = list(size = 13)), 
+      yaxis = list(title = "", 
+        # font = list(size = 13),
+        tickfont = list(size = 13)),
       showlegend = TRUE,
       margin = list(l = 100),
       annotations = if (caption) list(
         list(
           text = sprintf("ICES Stock Assessment Database, %s/%s. ICES, Copenhagen", cap_month, cap_year),
           xref = "paper", yref = "paper",
-          x = 0, y = -0.25, showarrow = FALSE,
+          x = 0, y = -0.1, showarrow = FALSE,
           font = list(size = 10), align = "left"
         )
       ) else NULL

--- a/R/mod_landings.R
+++ b/R/mod_landings.R
@@ -22,6 +22,7 @@ mod_landings_ui <- function(id) {
     #   ),
     mod_flex_header_ui(ns, "ecoregion_label", "current_date"),
     tabsetPanel(
+      id = ns("main_tabset"),
       tabPanel(
         "Landings",
         layout_sidebar(
@@ -92,7 +93,14 @@ mod_landings_server <- function(id, cap_year, cap_month, selected_ecoregion){
     })
 
     output$current_date <- renderText({
-      "Last update: December 05, 2024" # e.g., "May 26, 2025"
+      tab <- input$main_tabset
+      date_string <- switch(tab,
+        "Landings" = "Last update: December 05, 2024",
+        "Discards" = paste0("Last update: ", format(Sys.Date(), "%B %d, %Y"))
+        # "Last update: December 05, 2024" # default
+      )
+
+      date_string
     })
 
     SID <- reactive({      

--- a/R/mod_landings.R
+++ b/R/mod_landings.R
@@ -4,9 +4,9 @@
 #'
 #' @param id,input,output,session Internal parameters for {shiny}.
 #'
-#' @noRd 
+#' @noRd
 #'
-#' @importFrom shiny NS tagList 
+#' @importFrom shiny NS tagList
 #' @importFrom icesFO plot_discard_trends plot_discard_current plot_catch_trends
 #' @importFrom plotly ggplotly plotlyOutput renderPlotly
 #' @importFrom shinycssloaders withSpinner
@@ -14,48 +14,76 @@
 mod_landings_ui <- function(id) {
   ns <- NS(id)
   tagList(
-  #  div(
-  #     style = "display: flex; justify-content: space-between; align-items: center;
-  #          padding: 10px; font-weight: bold; font-size: 1.2em; margin-bottom: 0px;",
-  #     span(textOutput(ns("ecoregion_label"))),
-  #     span(textOutput(ns("current_date")))
-  #   ),
-  mod_flex_header_ui(ns, "ecoregion_label", "current_date"),
+    #  div(
+    #     style = "display: flex; justify-content: space-between; align-items: center;
+    #          padding: 10px; font-weight: bold; font-size: 1.2em; margin-bottom: 0px;",
+    #     span(textOutput(ns("ecoregion_label"))),
+    #     span(textOutput(ns("current_date")))
+    #   ),
+    mod_flex_header_ui(ns, "ecoregion_label", "current_date"),
     tabsetPanel(
-      tabPanel("Landings",
-        layout_sidebar(bg = "white", fg = "black", 
-          sidebar = sidebar(width = "33vw", bg = "white", fg = "black", 
-                            open = FALSE,
-                            uiOutput(ns("landings_text"))),
-          card(height = "85vh",
+      tabPanel(
+        "Landings",
+        layout_sidebar(
+          bg = "white", fg = "black",
+          sidebar = sidebar(
+            width = "33vw", bg = "white", fg = "black",
+            open = FALSE,
+            uiOutput(ns("landings_text"))
+          ),
+          card(
+            height = "85vh",
             card_header(
-              div(style = "margin-left: 12px;",
-                radioButtons(ns("landings_layer_selector"), NULL, inline = T,
-                  choices = c("Main landed species" = "COMMON_NAME", "Guild" = "GUILD", "Country" = "COUNTRY")))),
+              div(
+                style = "margin-left: 12px;",
+                radioButtons(ns("landings_layer_selector"), NULL,
+                  inline = T,
+                  choices = c("Main landed species" = "COMMON_NAME", "Guild" = "GUILD", "Country" = "COUNTRY")
+                )
+              )
+            ),
             card_body(withSpinner(
-              plotlyOutput(ns("landings_layer"), height = "65vh")))
-          ))),
-      tabPanel("Discards",
-        layout_sidebar(bg = "white", fg = "black", 
-          sidebar = sidebar(width = "33vw", bg = "white", fg = "black", 
-                            open = FALSE,
-                            uiOutput(ns("discards_text"))),
-          card(height = "85vh",
-            card_header(
-              div(style = "margin-left: 12px;",
-                radioButtons(ns("discards_layer_selector"), NULL, inline = TRUE,
-                             choices = c("Discard rates by guild   " = "rates", "Landings and discards (Stocks with recorded discards only)    " = "recorded", "Landings and discards (All_stocks) " = "all")))),
+              plotlyOutput(ns("landings_layer"), height = "65vh")
+            ))
+          )
+        )
+      ),
+      tabPanel(
+        "Discards",
+        layout_sidebar(
+          bg = "white", fg = "black",
+          sidebar = sidebar(
+            width = "33vw", bg = "white", fg = "black",
+            open = FALSE,
+            uiOutput(ns("discards_text"))
+          ),
+          card(
+            height = "50vh",
+            # card_header(
+            #   div(style = "margin-left: 12px;",
+            #     radioButtons(ns("discards_layer_selector"), NULL, inline = TRUE,
+            #                  choices = c("Discard rates by guild   " = "rates", "Landings and discards (Stocks with recorded discards only)    " = "recorded", "Landings and discards (All_stocks) " = "all")))),
             card_body(
-              conditionalPanel(ns = NS("landings_1"),
-                condition = "input.discards_layer_selector == 'rates'",
-                withSpinner(plotlyOutput(ns("discard_trends")))
-                ),
-              conditionalPanel(ns = NS("landings_1"),
-                condition = "input.discards_layer_selector == 'recorded'",
-                withSpinner(plotlyOutput(ns("recorded_discards")))
-                ),
-              conditionalPanel(ns = NS("landings_1"),
-                condition = "input.discards_layer_selector == 'all'",
+              #   conditionalPanel(ns = NS("landings_1"),
+              #     condition = "input.discards_layer_selector == 'rates'",
+              withSpinner(plotlyOutput(ns("discard_trends")))
+            )
+            #   conditionalPanel(ns = NS("landings_1"),
+            #     condition = "input.discards_layer_selector == 'recorded'",
+            #     withSpinner(plotlyOutput(ns("recorded_discards")))
+            #     ),
+            #   conditionalPanel(ns = NS("landings_1"),
+            #     condition = "input.discards_layer_selector == 'all'",
+            #     withSpinner(plotlyOutput(ns("all_discards")))
+            #   )
+            # )
+          ),
+          card(
+            height = "40vh",
+            card_body(
+              layout_column_wrap(
+                width = 1 / 2,
+                withSpinner(plotlyOutput(ns("recorded_discards"))),
                 withSpinner(plotlyOutput(ns("all_discards")))
               )
             )

--- a/R/mod_landings.R
+++ b/R/mod_landings.R
@@ -59,13 +59,14 @@ mod_landings_ui <- function(id) {
             uiOutput(ns("discards_text"))
           ),
           card(
-            height = "45vh",
+            
+            # height = "45vh",
             card_body(
+              style = "overflow-y: hidden;",
               withSpinner(plotlyOutput(ns("discard_trends")))
             )
           ),
           card(
-            height = "45vh",
             card_body(
               layout_column_wrap(
                 width = 1 / 2,
@@ -165,13 +166,13 @@ mod_landings_server <- function(id, cap_year, cap_month, selected_ecoregion){
     output$recorded_discards <- renderPlotly({
       catch_trends2 <- CLD_trends(format_sag(SAG(), SID())) %>% filter(Discards > 0)
       # ggplotly(plot_discard_current(CLD_trends(format_sag(SAG(), SID())), year, cap_year , cap_month, position_letter = ""))
-      plot_discard_current_plotly(catch_trends2, year = year, cap_year = cap_year, cap_month = cap_month)
+      plot_discard_current_plotly(catch_trends2, year = year, position_letter = "Stocks with recorded discards (2024)", cap_year = cap_year, cap_month = cap_month)
     })
 
     output$all_discards <- renderPlotly({
       # dat <- plot_discard_current_plotly(CLD_trends(format_sag(SAG(), SID())), year, cap_year = cap_year , cap_month = cap_month, return_data = TRUE)
       # ggplotly(plot_discard_current_order(CLD_trends(format_sag(SAG(), SID())), year-1, dat, cap_year , cap_month, position_letter = ""))
-      plot_discard_current_plotly(CLD_trends(format_sag(SAG(), SID())), year = year, cap_year = cap_year, cap_month = cap_month)
+      plot_discard_current_plotly(CLD_trends(format_sag(SAG(), SID())), year = year, position_letter = "All Stocks (2024)", cap_year = cap_year, cap_month = cap_month)
     })
     
   })

--- a/R/mod_landings.R
+++ b/R/mod_landings.R
@@ -58,28 +58,13 @@ mod_landings_ui <- function(id) {
             uiOutput(ns("discards_text"))
           ),
           card(
-            height = "50vh",
-            # card_header(
-            #   div(style = "margin-left: 12px;",
-            #     radioButtons(ns("discards_layer_selector"), NULL, inline = TRUE,
-            #                  choices = c("Discard rates by guild   " = "rates", "Landings and discards (Stocks with recorded discards only)    " = "recorded", "Landings and discards (All_stocks) " = "all")))),
+            height = "45vh",
             card_body(
-              #   conditionalPanel(ns = NS("landings_1"),
-              #     condition = "input.discards_layer_selector == 'rates'",
               withSpinner(plotlyOutput(ns("discard_trends")))
             )
-            #   conditionalPanel(ns = NS("landings_1"),
-            #     condition = "input.discards_layer_selector == 'recorded'",
-            #     withSpinner(plotlyOutput(ns("recorded_discards")))
-            #     ),
-            #   conditionalPanel(ns = NS("landings_1"),
-            #     condition = "input.discards_layer_selector == 'all'",
-            #     withSpinner(plotlyOutput(ns("all_discards")))
-            #   )
-            # )
           ),
           card(
-            height = "40vh",
+            height = "45vh",
             card_body(
               layout_column_wrap(
                 width = 1 / 2,


### PR DESCRIPTION
## Summary by Sourcery

Unify and streamline discard plotting by removing legacy ggplot-based functions in favor of a single Plotly implementation, enhance plot styling, and consolidate all discard visualizations into one Discards tab panel with a responsive UI and dynamic update date.

Enhancements:
- Remove deprecated ggplot-based discard plotting functions from R/fct_landings.R
- Refine plot_discard_trends_app_plotly for consistent styling (line width, axis and legend fonts, annotations)
- Restructure Discards tab in mod_landings_ui to display all discard plots together in a two-column layout
- Make header date reactive to the active tab for dynamic “Last update” messaging
- Update server logic to supply descriptive plot titles and labels to Plotly discard functions