### PR TITLE
feat: add tooltip functionality and improve plot selection UI

### DIFF
--- a/R/fct_helpers.R
+++ b/R/fct_helpers.R
@@ -53,3 +53,13 @@ mod_flex_header_ui <- function(ns, left_id, right_id) {
     span(textOutput(ns(right_id)))  
   )  
 }  
+
+
+
+make_tooltip_choice <- function(label_text, tooltip_html) {
+    tags$div(
+      class = "tooltip-wrapper",
+      HTML(label_text),
+      tags$span(class = "custom-tooltip", HTML(tooltip_html))
+    )
+  }

--- a/R/mod_mixfish_plot_selection.R
+++ b/R/mod_mixfish_plot_selection.R
@@ -1,14 +1,23 @@
-
 mod_mixfish_plot_selection_ui <- function(id) {
-  ns <- NS(id)
+  ns <- NS(id)  
+
   tagList(
-    uiOutput(ns("subregion_ui")),  # Placeholder for conditional UI
-    actionButton(ns("plot1"), "Headline"),
-    actionButton(ns("plot2"), "Effort By Fleet/Stock"),
-    actionButton(ns("plot3"), "Landings By Fleet/Stock"),
-    actionButton(ns("plot4"), "Landings By Stock"),
-    actionButton(ns("plot5"), "Catch Composition"),
-    
+    uiOutput(ns("subregion_ui")), # Placeholder for conditional UI
+
+    shinyWidgets::radioGroupButtons(
+      inputId = ns("tab_selected"),
+      label = "Select a plot:",
+      selected = "plot1",
+      direction = "vertical",
+      choiceNames = list(
+        make_tooltip_choice("Headline", "<strong>Headline</strong><br>Main highlights and signals"),
+        make_tooltip_choice("Effort By Fleet/Stock", "<strong>Effort</strong><br>Effort by fleet and stock"),
+        make_tooltip_choice("Landings By Fleet/Stock", "<strong>Landings</strong><br>by fleet and stock"),
+        make_tooltip_choice("Landings By Stock", "<strong>Landings</strong><br>Aggregated by stock"),
+        make_tooltip_choice("Catch Composition", "<strong>Composition</strong><br>Species-level breakdown")
+      ),
+      choiceValues = c("plot1", "plot2", "plot3", "plot4", "plot5")
+    )
   )
 }
 
@@ -18,7 +27,7 @@ mod_mixfish_plot_selection_server <- function(id, selected_ecoregion) {
     ns <- session$ns
 
     selected_subRegion <- reactiveVal(NULL)
-    selected_plot <- reactiveVal(NULL)
+    selected_plot <- reactiveVal("plot1")
 
     # Conditionally render subregion selectInput based on ecoregion
     output$subregion_ui <- renderUI({
@@ -40,8 +49,8 @@ mod_mixfish_plot_selection_server <- function(id, selected_ecoregion) {
           selected = new_choices[1]
         )
       } else {
-        selected_subRegion(NULL)  # Reset if no subregion relevant
-        NULL  # No UI shown
+        selected_subRegion(NULL) # Reset if no subregion relevant
+        NULL # No UI shown
       }
     })
 
@@ -49,29 +58,15 @@ mod_mixfish_plot_selection_server <- function(id, selected_ecoregion) {
       selected_subRegion(input$subRegion)
     })
 
-    observeEvent(input$plot1, {
-      selected_plot("plot1")
+
+    observeEvent(input$tab_selected, {
+      selected_plot(input$tab_selected)
     })
 
-    observeEvent(input$plot2, {
-      selected_plot("plot2")
-    })
-
-    observeEvent(input$plot3, {
-      selected_plot("plot3")
-    })
-
-    observeEvent(input$plot4, {
-      selected_plot("plot4")
-    })
-
-    observeEvent(input$plot5, {
-      selected_plot("plot5")
-    })
-    
+    # Reset selected_plot when ecoregion changes
     observeEvent(selected_ecoregion(), {
       # reset plot
-      selected_plot(NULL)
+      selected_plot("plot1")
     })
 
     list(

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -375,10 +375,10 @@ caption {
   visibility: visible;
 }
 
-.btn-group, .btn-group-vertical {
-  width: 18vw;
-  position: center;
-  margin: 0 auto;
-  display: inline-block;
+.btn-group, .btn-group-vertical {  
+  width: 18vw;  
+  margin: 0 auto;  
+  display: inline-block;  
+  text-align: center;
   vertical-align: middle;
 }

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -349,3 +349,36 @@ caption {
 .sidebar {
   overflow: hidden;
 }
+
+.tooltip-wrapper {
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+  }
+.custom-tooltip {
+  visibility: hidden;
+  background-color: #333;
+  color: #fff;
+  text-align: left;
+  border-radius: 6px;
+  padding: 8px;
+  position: absolute;
+  z-index: 1;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: 5px;
+  white-space: nowrap;
+  font-size: 0.85em;
+  width: 200px;
+}
+.tooltip-wrapper:hover .custom-tooltip {
+  visibility: visible;
+}
+
+.btn-group, .btn-group-vertical {
+  width: 18vw;
+  position: center;
+  margin: 0 auto;
+  display: inline-block;
+  vertical-align: middle;
+}


### PR DESCRIPTION
introduced a groupRadioButtons, this will need a bit more CSS work to harmonize it with the rest of the app

## Summary by Sourcery

Implement tooltip-driven plot selection via a radio button group, streamline server logic, and add accompanying CSS for consistent styling.

New Features:
- Add a vertical radioGroupButtons input with tooltips for selecting plots

Enhancements:
- Set default plot selection to 'plot1' on initialization and ecoregion change
- Consolidate individual plot button observers into a single observer for tab selection

Chores:
- Introduce a helper function `make_tooltip_choice` to generate tooltip-wrapped labels