### PR TITLE
added stocks with proxy ref points 

### DIFF
--- a/R/fct_stock_status.R
+++ b/R/fct_stock_status.R
@@ -183,9 +183,9 @@ format_sag <- function(sag, sid){
         out <- dplyr::anti_join(df1, check)
 }
 
-add_proxyRefPoints <- function(sag_formatted) {
+add_proxyRefPoints <- function(sag_formatted, custom_refpoints_path) {
         
-        custom_RefPoints <- read.table("data/custom_refpoints_2025.csv",
+        custom_RefPoints <- read.table(custom_refpoints_path,
                 sep = ",",
                 header = TRUE,
                 stringsAsFactors = FALSE
@@ -1352,9 +1352,10 @@ plot_CLD_bar_app <- function(x, guild, return_data = FALSE) {
   # --- Filter by guild
   df <- if (identical(guild, "All")) x else dplyr::filter(x, FisheriesGuild %in% guild)
 
-  # --- Ensure proxy flags exist
-  if (!"F_proxy" %in% names(df)) df$F_proxy <- FALSE
-  if (!"B_proxy" %in% names(df)) df$B_proxy <- FALSE
+   # --- Ensure proxy flags exist  
+  if (!"F_proxy" %in% names(df)) warning("Missing 'F_proxy' column in input data. This may indicate an upstream data issue.")  
+  if (!"B_proxy" %in% names(df)) warning("Missing 'B_proxy' column in input data. This may indicate an upstream data issue.")  
+
 
   # --- Build 'total' per stock (max of Catches/Landings across time)
   df <- df %>%

--- a/R/mod_stock_status.R
+++ b/R/mod_stock_status.R
@@ -251,7 +251,7 @@ mod_stock_status_server <- function(
     ######################### Status summary tab #################################################
 
     catch_current <- reactive({
-      stockstatus_CLD_current_proxy(add_proxyRefPoints(format_sag(shared$SAG, shared$SID)))
+      stockstatus_CLD_current_proxy(add_proxyRefPoints(format_sag(shared$SAG, shared$SID), custom_refpoints_path = "data/custom_refpoints_2025.csv"))
     })
 
     output$status_summary_ices <- renderPlot({
@@ -443,7 +443,7 @@ mod_stock_status_server <- function(
 
     ##################### Stock trends tab ###############################################
     trends_data <- reactive({
-      stock_trends_proxy(add_proxyRefPoints(format_sag(shared$SAG, shared$SID)))
+      stock_trends_proxy(add_proxyRefPoints(format_sag(shared$SAG, shared$SID), custom_refpoints_path = "data/custom_refpoints_2025.csv"))
     })
 
     output$status_trends <- renderPlotly({


### PR DESCRIPTION
## Summary by Sourcery

Enable custom proxy reference points by reading overrides from a CSV, applying them to FMSY and MSYBtrigger, flagging and naming those proxies, and updating all downstream calculations and plots to clearly differentiate proxy versus official reference points.

New Features:
- Integrate custom proxy reference points from CSV into the stock assessment pipeline via a new add_proxyRefPoints function
- Introduce proxy-aware status and trend computation functions (stockstatus_CLD_current_proxy and stock_trends_proxy)

Enhancements:
- Update getSAG API endpoints to use the new SAG_API base paths
- Refactor plot_stock_trends to visually distinguish proxy vs official reference points with distinct line types, hover info, and dynamic legends
- Enhance CLD bar and Kobe plots to flag proxy reference points with hollow markers and tailored legends
- Wire the new proxy functions into the Shiny server logic for status summary and trends