### PR TITLE
ui tweaks

### DIFF
--- a/R/mod_landings.R
+++ b/R/mod_landings.R
@@ -80,7 +80,7 @@ mod_landings_ui <- function(id) {
           card(
             height = "85vh",
             card_header(
-              radioButtons(ns("landings_layer_selector"), NULL,
+              radioButtons(ns("landings_layer_selector"), "Select grouping:",
                 inline = TRUE,
                 choices = c(
                   "Main landed species" = "Common name",

--- a/R/mod_navigation_page.R
+++ b/R/mod_navigation_page.R
@@ -47,7 +47,7 @@ mod_navigation_page_ui <- function(id) {
           width = 1 / 2,
           card(
             full_screen = FALSE,
-            card_header("Select an ICES ecoregion"),
+            card_header("Select an ICES ecoregion:"),
             tags$style(type = "text/css", "#map {margin-left: auto; margin-right: auto; margin-bottom: auto;  max-width: 97%; height: auto;}"),
             withSpinner(leafletOutput(ns("map"), width = "90%")),
             tags$style(type = "text/css", "#selected_locations {margin-left: auto; margin-right: auto; margin-bottom: auto;}"),

--- a/R/mod_stock_status.R
+++ b/R/mod_stock_status.R
@@ -140,7 +140,7 @@ mod_stock_status_ui <- function(id) {
             card(
               height = "85vh", full_screen = TRUE,
               card_header(
-                radioButtons(ns("status_trend_selector"), NULL,
+                radioButtons(ns("status_trend_selector"), "Select a fisheries guild:",
                   inline = TRUE,
                   choices = c(
                     "Benthic"       = "benthic",
@@ -173,7 +173,7 @@ mod_stock_status_ui <- function(id) {
                 6,
                 div(
                   style = "display: flex; justify-content: space-between; align-items: center; width: 100%; padding: 0 16px;",
-                  radioButtons(ns("status_kobe_cld_selector"),NULL,
+                  radioButtons(ns("status_kobe_cld_selector"), "Select a fisheries guild:",
                     inline = TRUE,
                     choices = c(
                       "All Stocks"= "All",
@@ -700,7 +700,7 @@ mod_stock_status_server <- function(
       div(
         id = "custom_slider",
         sliderInput(ns("n_selector"), 
-          HTML("Choose <em>n</em> of stocks"),
+          HTML("Select <em>n</em> of stocks:"),
           min = 1, 
           max = slider_max, 
           value = min(10, slider_max), 


### PR DESCRIPTION
remove 'select' instructions from headers and order guilds alphabetically

## Summary by Sourcery

Tweak stock status UI group selectors for clarity and consistency.

Enhancements:
- Remove instructional label text from stock status group radio button headers.
- Alphabetically sort guild/group choices in stock status trend and Kobe chart selectors for a more intuitive UI.